### PR TITLE
Factor out HTTP request function

### DIFF
--- a/lib/AdminClient/index.js
+++ b/lib/AdminClient/index.js
@@ -1,14 +1,11 @@
-const https = require('https')
-const Q = require('kew')
 const SymConfigLoader = require('../SymConfigLoader')
 const SymBotAuth = require('../SymBotAuth')
+const request = require('../Request')
 
 var AdminClient = {}
 
 // List Enterprise streams for calling users company using https://rest-api.symphony.com/docs/list-streams-for-enterprise-v2
 AdminClient.adminListEnterpriseStreamsV2 = (streamTypes, scope, origin, privacy, status, startDate, endDate, skip = 0, limit = 100) => {
-  var defer = Q.defer()
-
   var body = {
     'streamTypes': streamTypes,
     'scope': scope,
@@ -31,29 +28,11 @@ AdminClient.adminListEnterpriseStreamsV2 = (streamTypes, scope, origin, privacy,
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'AdminClient/adminListEnterpriseStreamsV2/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+  return request(options, 'AdminClient/adminListEnterpriseStreamsV2', body)
 }
 
 // List all current members of a stream using https://rest-api.symphony.com/docs/stream-members
 AdminClient.streamMembers = (id, skip = 0, limit = 1000) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -66,29 +45,12 @@ AdminClient.streamMembers = (id, skip = 0, limit = 1000) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'AdminClient/streamMembers/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'AdminClient/streamMembers')
 }
 
 // Import messages to Symphony using https://rest-api.symphony.com/docs/import-message-v4
 // Note: Formatting for messages https://rest-api.symphony.com/v1.52/docs/import-message-v4#v4importedmessage-format
 AdminClient.importMessages = (messageList) => {
-  var defer = Q.defer()
-
   var body = {
     'messageList': messageList
   }
@@ -106,29 +68,11 @@ AdminClient.importMessages = (messageList) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'AdminClient/importMessages/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+  return request(options, 'AdminClient/importMessages', body)
 }
 
 // Suppress a message from a stream using https://rest-api.symphony.com/docs/suppress-message
 AdminClient.suppressMessage = (id) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -141,22 +85,7 @@ AdminClient.suppressMessage = (id) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'AdminClient/suppressMessage/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'AdminClient/suppressMessage')
 }
 
 module.exports = AdminClient

--- a/lib/AdminUserClient/index.js
+++ b/lib/AdminUserClient/index.js
@@ -1,14 +1,11 @@
-const https = require('https')
-const Q = require('kew')
 const SymConfigLoader = require('../SymConfigLoader')
 const SymBotAuth = require('../SymBotAuth')
+const request = require('../Request')
 
 var AdminUserClient = {}
 
 // Get User V2 using https://rest-api.symphony.com/reference#get-user-v2
 AdminUserClient.getUser = (id) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -21,28 +18,11 @@ AdminUserClient.getUser = (id) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'AdminUserClient/getUser/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'AdminUserClient/getUser')
 }
 
 // List all users using https://rest-api.symphony.com/reference#list-users-v2
 AdminUserClient.listUsers = (skip = 0, limit = 1000) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -55,22 +35,7 @@ AdminUserClient.listUsers = (skip = 0, limit = 1000) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'AdminUserClient/listUsers/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'AdminUserClient/listUsers')
 }
 
 module.exports = AdminUserClient

--- a/lib/ConnectionsClient/index.js
+++ b/lib/ConnectionsClient/index.js
@@ -1,7 +1,6 @@
-const https = require('https')
-const Q = require('kew')
 const SymConfigLoader = require('../SymConfigLoader')
 const SymBotAuth = require('../SymBotAuth')
+const request = require('../Request')
 
 var ConnectionsClient = {}
 
@@ -13,8 +12,6 @@ ConnectionsClient.ALL = 'All'
 
 // List pending outbound connection requests using https://rest-api.symphony.com/docs/list-connections
 ConnectionsClient.getPendingConnections = (status) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -27,28 +24,11 @@ ConnectionsClient.getPendingConnections = (status) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'ConnectionsClient/getPendingConnections/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'ConnectionsClient/getPendingConnections')
 }
 
 // List pending inbound connection requests using https://rest-api.symphony.com/docs/list-connections
 ConnectionsClient.getInboundPendingConnections = (status) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -61,28 +41,11 @@ ConnectionsClient.getInboundPendingConnections = (status) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'ConnectionsClient/getInboundPendingConnections/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'ConnectionsClient/getInboundPendingConnections')
 }
 
 // List all current connections using https://rest-api.symphony.com/docs/list-connections
 ConnectionsClient.getAllConnections = (status) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -95,28 +58,11 @@ ConnectionsClient.getAllConnections = (status) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'ConnectionsClient/getAllConnections/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'ConnectionsClient/getAllConnections')
 }
 
 // List accepted connections using https://rest-api.symphony.com/docs/list-connections
 ConnectionsClient.getAcceptedConnections = (status) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -129,28 +75,11 @@ ConnectionsClient.getAcceptedConnections = (status) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'ConnectionsClient/getAcceptedConnections/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'ConnectionsClient/getAcceptedConnections')
 }
 
 // List rejected connections using https://rest-api.symphony.com/docs/list-connections
 ConnectionsClient.getRejectedConnections = (status) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -163,28 +92,11 @@ ConnectionsClient.getRejectedConnections = (status) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'ConnectionsClient/getRejectedConnections/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'ConnectionsClient/getRejectedConnections')
 }
 
 // List connection status for an array of users https://rest-api.symphony.com/docs/list-connections
 ConnectionsClient.getConnections = (status, userIds) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -197,28 +109,11 @@ ConnectionsClient.getConnections = (status, userIds) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'ConnectionsClient/getConnections/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'ConnectionsClient/getConnections')
 }
 
 // Accept connection request from a requesting user https://rest-api.symphony.com/docs/accepted-connection
 ConnectionsClient.acceptConnectionRequest = (userId) => {
-  var defer = Q.defer()
-
   var body = {
     'userId': userId
   }
@@ -235,29 +130,11 @@ ConnectionsClient.acceptConnectionRequest = (userId) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'ConnectionsClient/acceptConnectionRequest/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+  return request(options, 'ConnectionsClient/acceptConnectionRequest', body)
 }
 
 // Reject connection request from a requesting user https://rest-api.symphony.com/docs/reject-connection
 ConnectionsClient.rejectConnectionRequest = (userId) => {
-  var defer = Q.defer()
-
   var body = {
     'userId': userId
   }
@@ -274,29 +151,11 @@ ConnectionsClient.rejectConnectionRequest = (userId) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'ConnectionsClient/rejectConnectionRequest/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+  return request(options, 'ConnectionsClient/rejectConnectionRequest', body)
 }
 
 // Create a connection request to another user https://rest-api.symphony.com/docs/create-connection
 ConnectionsClient.sendConnectionRequest = (userId) => {
-  var defer = Q.defer()
-
   var body = {
     'userId': userId
   }
@@ -313,29 +172,11 @@ ConnectionsClient.sendConnectionRequest = (userId) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'ConnectionsClient/sendConnectionRequest/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+  return request(options, 'ConnectionsClient/sendConnectionRequest', body)
 }
 
 // Remove an existing connection to another user https://rest-api.symphony.com/docs/remove-connection
 ConnectionsClient.removeConnection = (userId) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -348,28 +189,11 @@ ConnectionsClient.removeConnection = (userId) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'ConnectionsClient/removeConnection/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'ConnectionsClient/removeConnection')
 }
 
 // Get connection status for another user https://rest-api.symphony.com/docs/get-connection
 ConnectionsClient.getConnectionRequestStatus = (userId) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -382,22 +206,7 @@ ConnectionsClient.getConnectionRequestStatus = (userId) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'ConnectionsClient/getConnectionRequestStatus/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'ConnectionsClient/getConnectionRequestStatus')
 }
 
 module.exports = ConnectionsClient

--- a/lib/FirehoseClient/index.js
+++ b/lib/FirehoseClient/index.js
@@ -4,6 +4,7 @@ const PubSub = require('pubsub-js')
 const SymBotAuth = require('../SymBotAuth')
 const SymConfigLoader = require('../SymConfigLoader')
 const SymMessageParser = require('../SymMessageParser')
+const request = require('../Request')
 
 var FirehoseClient = {}
 
@@ -13,8 +14,6 @@ FirehoseClient.registerBot = (token) => {
 
 // Create Firehose v1.0 using https://rest-api.symphony.com/v1.53/reference?showHidden=1a1dd#create-firehose-v4
 FirehoseClient.createFirehose = () => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.agentHost,
     'port': SymConfigLoader.SymConfig.agentPort,
@@ -27,25 +26,7 @@ FirehoseClient.createFirehose = () => {
     'agent': SymConfigLoader.SymConfig.agentProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'FirehoseClient/createFirehose/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-  req.on('error', function (e) {
-    console.log('error', e)
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'FirehoseClient/createFirehose')
 }
 
 // Read Firehose v1.0 using https://rest-api.symphony.com/v1.53/reference?showHidden=1a1dd#read-firehose-v4

--- a/lib/OBOClient/index.js
+++ b/lib/OBOClient/index.js
@@ -3,13 +3,12 @@ const FormData = require('form-data')
 const Q = require('kew')
 const SymConfigLoader = require('../SymConfigLoader')
 const SymBotAuth = require('../SymBotAuth')
+const request = require('../Request')
 
 var OBOClient = {}
 
 // OBO List all user connections using https://rest-api.symphony.com/reference#list-connections
 OBOClient.oboGetAllConnections = (status) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -22,28 +21,11 @@ OBOClient.oboGetAllConnections = (status) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'OBOClient/oboGetAllConnections/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'OBOClient/oboGetAllConnections')
 }
 
 // OBO Get connection information using https://rest-api.symphony.com/reference#get-connection
 OBOClient.oboGetConnection = (userId) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -56,28 +38,11 @@ OBOClient.oboGetConnection = (userId) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'OBOClient/oboGetConnection/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'OBOClient/oboGetConnection')
 }
 
 // OBO Create IM or MIM (non inclusive) using https://rest-api.symphony.com/reference#create-im-or-mim-admin
 OBOClient.oboGetUserIMStreamId = (userIds) => {
-  var defer = Q.defer()
-
   var body = {
     'userIds': userIds
   }
@@ -94,22 +59,7 @@ OBOClient.oboGetUserIMStreamId = (userIds) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'OBOClient/oboGetUserIMStreamId/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+  return request(options, 'OBOClient/oboGetUserIMStreamId', body)
 }
 
 //

--- a/lib/PresenceClient/index.js
+++ b/lib/PresenceClient/index.js
@@ -1,7 +1,6 @@
-const https = require('https')
-const Q = require('kew')
 const SymConfigLoader = require('../SymConfigLoader')
 const SymBotAuth = require('../SymBotAuth')
+const request = require('../Request')
 
 var PresenceClient = {}
 
@@ -15,8 +14,6 @@ PresenceClient.STATUS_OUT_OF_OFFICE = 'OUT_OF_OFFICE'
 PresenceClient.STATUS_OFF_WORK = 'OFF_WORK'
 
 PresenceClient.getUserPresence = (userId, local) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -28,27 +25,10 @@ PresenceClient.getUserPresence = (userId, local) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'UsersClient/getUserPresence/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+    return request(options, 'UsersClient/getUserPresence')
 }
 
 PresenceClient.setPresence = (status) => {
-  var defer = Q.defer()
-
   var body = {
     'category': status
   }
@@ -64,28 +44,10 @@ PresenceClient.setPresence = (status) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'UsersClient/setPresence/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+    return request(options, 'UsersClient/setPresence', body)
 }
 
 PresenceClient.registerInterestExtUser = (idList) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -97,23 +59,7 @@ PresenceClient.registerInterestExtUser = (idList) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data ', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'UsersClient/registerInterestExtUser/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(idList))
-  req.end()
-
-  return defer.promise
+    return request(options, 'UsersClient/registerInterestExtUser')
 }
 
 module.exports = PresenceClient

--- a/lib/Request/index.js
+++ b/lib/Request/index.js
@@ -1,0 +1,38 @@
+const https = require('https')
+const Q = require('kew')
+const SymBotAuth = require('../SymBotAuth')
+
+module.exports = function request(options, debugId, body) {
+  const defer = Q.defer()
+
+  const errorHandler = err => {
+    if (SymBotAuth.debug) {
+      console.log('[ERROR]', debugId + '/err', err)
+    }
+    defer.reject({ 'status': 'error' })
+  }
+
+  const req = https.request(options, res => {
+    let str = ''
+    res.on('data', chunk => {
+      str += chunk
+    })
+    res.on('end', () => {
+      if (SymBotAuth.debug) {
+        console.log('[DEBUG]', debugId + '/str', str)
+      }
+      defer.resolve((str === '') ? {} : JSON.parse(str))
+    })
+    res.on('error', errorHandler)
+  })
+
+  req.on('error', errorHandler)
+
+  if (body) {
+    req.write(JSON.stringify(body))
+  }
+
+  req.end()
+
+  return defer.promise
+}

--- a/lib/SignalsClient/index.js
+++ b/lib/SignalsClient/index.js
@@ -1,14 +1,11 @@
-const https = require('https')
-const Q = require('kew')
 const SymConfigLoader = require('../SymConfigLoader')
 const SymBotAuth = require('../SymBotAuth')
+const request = require('../Request')
 
 var SignalsClient = {}
 
 // List signals on behalf of the service user using https://rest-api.symphony.com/docs/list-signals
 SignalsClient.listSignals = (skip = 0, limit = 50) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -22,28 +19,11 @@ SignalsClient.listSignals = (skip = 0, limit = 50) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'SignalsClient/listSignals/str', str)
-      }
-      defer.resolve((str === '') ? {} : JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'SignalsClient/listSignals')
 }
 
 // Get information about a signal using https://rest-api.symphony.com/docs/get-signal
 SignalsClient.getSignal = (id) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -57,28 +37,11 @@ SignalsClient.getSignal = (id) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'SignalsClient/getSignal/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'SignalsClient/getSignal')
 }
 
 // Create a new signal using https://rest-api.symphony.com/docs/create-signal
 SignalsClient.createSignal = (name, query, visibleOnProfile = true, companyWide = false) => {
-  var defer = Q.defer()
-
   var body = {
     'name': name,
     'query': query,
@@ -99,29 +62,11 @@ SignalsClient.createSignal = (name, query, visibleOnProfile = true, companyWide 
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'SignalsClient/createSignal/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+  return request(options, 'SignalsClient/createSignal', body)
 }
 
 // Update an existing signal using https://rest-api.symphony.com/docs/update-signal
 SignalsClient.updateSignal = (id, name, query, visibleOnProfile, companyWide) => {
-  var defer = Q.defer()
-
   var body = {
     'name': name,
     'query': query,
@@ -142,29 +87,11 @@ SignalsClient.updateSignal = (id, name, query, visibleOnProfile, companyWide) =>
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'SignalsClient/updateSignal/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+  return request(options, 'SignalsClient/updateSignal', body)
 }
 
 // Delete an existing signal using https://rest-api.symphony.com/docs/delete-signal
 SignalsClient.deleteSignal = (id) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -178,29 +105,12 @@ SignalsClient.deleteSignal = (id) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'SignalsClient/deleteSignal/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'SignalsClient/deleteSignal')
 }
 
 // Subscribe user(s) to an existing signal using https://rest-api.symphony.com/docs/subscribe-signal
 // Note: To subscribe an entire pod to a Signal, set the companyWide field to true using SignalsClient.updateSignal
 SignalsClient.subscribeSignal = (id, userIds, userCanUnsubscribe) => {
-  var defer = Q.defer()
-
   var body = {
     'users': userIds
   }
@@ -218,29 +128,11 @@ SignalsClient.subscribeSignal = (id, userIds, userCanUnsubscribe) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'SignalsClient/subscribeSignal/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+  return request(options, 'SignalsClient/subscribeSignal', body)
 }
 
 // Unsubscribe user(s) to an existing signal using https://rest-api.symphony.com/docs/unsubscribe-signal
 SignalsClient.unsubscribeSignal = (id, userIds) => {
-  var defer = Q.defer()
-
   var body = {
     'users': userIds
   }
@@ -258,29 +150,11 @@ SignalsClient.unsubscribeSignal = (id, userIds) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'SignalsClient/unsubscribeSignal/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+  return request(options, 'SignalsClient/unsubscribeSignal', body)
 }
 
 // List users subscribed to an existing signal using https://rest-api.symphony.com/docs/subscribers
 SignalsClient.getSignalSubscribers = (id, skip = 0, limit = 50) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -294,22 +168,7 @@ SignalsClient.getSignalSubscribers = (id, skip = 0, limit = 50) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'SignalsClient/getSignalSubscribers/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'SignalsClient/getSignalSubscribers')
 }
 
 module.exports = SignalsClient

--- a/lib/StreamsClient/index.js
+++ b/lib/StreamsClient/index.js
@@ -1,14 +1,11 @@
-const https = require('https')
-const Q = require('kew')
 const SymConfigLoader = require('../SymConfigLoader')
 const SymBotAuth = require('../SymBotAuth')
+const request = require('../Request')
 
 var StreamsClient = {}
 
 // Get StreamID for user(s) using https://rest-api.symphony.com/docs/create-im-or-mim
 StreamsClient.getUserIMStreamId = (userIDs) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -21,28 +18,11 @@ StreamsClient.getUserIMStreamId = (userIDs) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'StreamsClient/getUserIMStreamId/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-  req.write(JSON.stringify(userIDs))
-  req.end()
-
-  return defer.promise
+  return request(options, 'StreamsClient/getUserIMStreamId', userIDs)
 }
 
 // Create room using https://rest-api.symphony.com/docs/create-room-v3
 StreamsClient.createRoom = (room, description, keywords, membersCanInvite = true, discoverable = true, anyoneCanJoin = false, readOnly = false, copyProtected = false, crossPod = false, viewHistory = false) => {
-  var defer = Q.defer()
-
   var body = {
     'name': room,
     'description': description,
@@ -68,29 +48,11 @@ StreamsClient.createRoom = (room, description, keywords, membersCanInvite = true
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'StreamsClient/createRoom/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+  return request(options, 'StreamsClient/createRoom', body)
 }
 
 // Update room using https://rest-api.symphony.com/docs/update-room-v3
 StreamsClient.updateRoom = (streamId, room, description, keywords, membersCanInvite, discoverable, anyoneCanJoin, readOnly, copyProtected, crossPod, viewHistory) => {
-  var defer = Q.defer()
-
   var body = {
     'name': room,
     'description': description,
@@ -116,29 +78,11 @@ StreamsClient.updateRoom = (streamId, room, description, keywords, membersCanInv
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'StreamsClient/updateRoom/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+  return request(options, 'StreamsClient/updateRoom', body)
 }
 
 // Room Information using https://rest-api.symphony.com/docs/room-info-v3
 StreamsClient.getRoomInfo = (streamId) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -150,28 +94,11 @@ StreamsClient.getRoomInfo = (streamId) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'StreamsClient/getRoomInfo/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'StreamsClient/getRoomInfo')
 }
 
 // Re-Activate Room using https://rest-api.symphony.com/docs/de-or-re-activate-room
 StreamsClient.activateRoom = (streamId) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -183,28 +110,11 @@ StreamsClient.activateRoom = (streamId) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'StreamsClient/activateRoom/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'StreamsClient/activateRoom')
 }
 
 // De-Activate Room using https://rest-api.symphony.com/docs/de-or-re-activate-room
 StreamsClient.deactivateRoom = (streamId) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -216,28 +126,11 @@ StreamsClient.deactivateRoom = (streamId) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'StreamsClient/deactivateRoom/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'StreamsClient/deactivateRoom')
 }
 
 // Room Members using https://rest-api.symphony.com/docs/room-members
 StreamsClient.getRoomMembers = (streamId) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -249,28 +142,11 @@ StreamsClient.getRoomMembers = (streamId) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'StreamsClient/getRoomMembers/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'StreamsClient/getRoomMembers')
 }
 
 // Add Member to existing room using https://rest-api.symphony.com/docs/add-member
 StreamsClient.addMemberToRoom = (streamId, userId) => {
-  var defer = Q.defer()
-
   var body = {
     'id': userId
   }
@@ -287,29 +163,11 @@ StreamsClient.addMemberToRoom = (streamId, userId) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'StreamsClient/addMemberToRoom/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+  return request(options, 'StreamsClient/addMemberToRoom', body)
 }
 
 // Remove Member to existing room using https://rest-api.symphony.com/docs/remove-member
 StreamsClient.removeMemberFromRoom = (streamId, userId) => {
-  var defer = Q.defer()
-
   var body = {
     'id': userId
   }
@@ -326,29 +184,11 @@ StreamsClient.removeMemberFromRoom = (streamId, userId) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'StreamsClient/removeMemberFromRoom/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+  return request(options, 'StreamsClient/removeMemberFromRoom', body)
 }
 
 // Promote Member to owner of room using https://rest-api.symphony.com/docs/promote-owner
 StreamsClient.promoteUserToOwner = (streamId, userId) => {
-  var defer = Q.defer()
-
   var body = {
     'id': userId
   }
@@ -365,29 +205,11 @@ StreamsClient.promoteUserToOwner = (streamId, userId) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'StreamsClient/promoteUserToOwner/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+  return request(options, 'StreamsClient/promoteUserToOwner', body)
 }
 
 // Demote Member from owner of room using https://rest-api.symphony.com/docs/promote-owner
 StreamsClient.demoteUserFromOwner = (streamId, userId) => {
-  var defer = Q.defer()
-
   var body = {
     'id': userId
   }
@@ -404,29 +226,11 @@ StreamsClient.demoteUserFromOwner = (streamId, userId) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'StreamsClient/demoteUserFromOwner/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+  return request(options, 'StreamsClient/demoteUserFromOwner', body)
 }
 
 // Search Rooms using https://rest-api.symphony.com/docs/search-rooms-v3
 StreamsClient.searchRooms = (skip = 0, limit = 100, query, labels, active = true, includePrivateRooms = false, creator, owner, member, sortOrder = 'RELEVANCE') => {
-  var defer = Q.defer()
-
   var body = {
     'query': query,
     'labels': labels,
@@ -450,29 +254,11 @@ StreamsClient.searchRooms = (skip = 0, limit = 100, query, labels, active = true
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'StreamsClient/searchRooms/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+  return request(options, 'StreamsClient/searchRooms', body)
 }
 
 // List User Streams using https://rest-api.symphony.com/docs/list-user-streams
 StreamsClient.getUserStreams = (skip = 0, limit = 100, streamTypes, includeInactiveStreams) => {
-  var defer = Q.defer()
-
   var body = {
     'streamTypes': streamTypes,
     'includeInactiveStreams': includeInactiveStreams
@@ -490,23 +276,7 @@ StreamsClient.getUserStreams = (skip = 0, limit = 100, streamTypes, includeInact
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'StreamsClient/getUserStreams/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.write(JSON.stringify(body))
-  req.end()
-
-  return defer.promise
+  return request(options, 'StreamsClient/getUserStreams', body)
 }
 
 module.exports = StreamsClient

--- a/lib/SymBotAuth/index.js
+++ b/lib/SymBotAuth/index.js
@@ -1,7 +1,6 @@
 const fs = require('fs')
-const https = require('https')
-const Q = require('kew')
 const nJwt = require('njwt')
+const request = require('../Request')
 
 var SymBotAuth = {
   debug: false
@@ -9,13 +8,11 @@ var SymBotAuth = {
 
 // Session Authentication using https://rest-api.symphony.com/reference#session-authenticate
 SymBotAuth.sessionAuthenticate = (symConfig) => {
-  var defer = Q.defer()
-
-  var options = {}
-  var jwtToken
+  var options
+  var body
 
   if (symConfig.authType === 'rsa') {
-    jwtToken = { 'token': SymBotAuth.getJwtToken(symConfig) }
+    body = { 'token': SymBotAuth.getJwtToken(symConfig) }
 
     options = {
       'hostname': symConfig.podHost,
@@ -40,42 +37,19 @@ SymBotAuth.sessionAuthenticate = (symConfig) => {
     }
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'SymBotAuth/sessionAuthenticate/str', str)
-      }
-      var SymSessionToken = JSON.parse(str)
-      SymBotAuth.sessionAuthToken = SymSessionToken.token
-      defer.resolve(SymSessionToken.token)
-    })
-    res.on('error', function (err) {
-      console.log('[ERROR]', 'SymBotAuth/sessionAuthenticate/err', err)
-    })
+  return request(options, 'SymBotAuth/sessionAuthenticate', body).then(({ token }) => {
+    SymBotAuth.sessionAuthToken = token
+    return token
   })
-
-  if (symConfig.authType === 'rsa') {
-    req.write(JSON.stringify(jwtToken))
-  }
-
-  req.end()
-
-  return defer.promise
 }
 
 // KeyManager Authentication using https://rest-api.symphony.com/reference#key-manager-authenticate
 SymBotAuth.kmAuthenticate = (symConfig) => {
-  var defer = Q.defer()
-
-  var options = {}
-  var jwtToken
+  var options
+  var body
 
   if (symConfig.authType === 'rsa') {
-    jwtToken = { 'token': SymBotAuth.jwtToken }
+    body = { 'token': SymBotAuth.jwtToken }
     options = {
       'hostname': symConfig.keyAuthHost,
       'port': symConfig.keyAuthPort,
@@ -99,39 +73,19 @@ SymBotAuth.kmAuthenticate = (symConfig) => {
     }
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'SymBotAuth/kmAuthenticate/str', str)
-      }
-      var SymKmToken = JSON.parse(str)
-      SymBotAuth.kmAuthToken = SymKmToken.token
-      defer.resolve(SymKmToken.token)
-    })
+  return request(options, 'SymBotAuth/kmAuthenticate', body).then(({ token }) => {
+    SymBotAuth.kmAuthToken = token
+    return token
   })
-
-  if (symConfig.authType === 'rsa') {
-    req.write(JSON.stringify(jwtToken))
-  }
-
-  req.end()
-
-  return defer.promise
 }
 
 // Application Authentication required for obtaining user info https://rest-api.symphony.com/reference#obo-app-authenticate
 SymBotAuth.applicationAuthenticate = (symConfig) => {
-  var defer = Q.defer()
-
-  var options = {}
-  var jwtToken
+  var options
+  var body
 
   if (symConfig.authType === 'rsa') {
-    jwtToken = { 'token': SymBotAuth.getJwtToken(symConfig) }
+    body = { 'token': SymBotAuth.getJwtToken(symConfig) }
 
     options = {
       'hostname': symConfig.podHost,
@@ -156,43 +110,19 @@ SymBotAuth.applicationAuthenticate = (symConfig) => {
     }
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'SymBotAuth/applicationAuthenticate/str', str)
-      }
-      var SymAppAuthToken = JSON.parse(str)
-      console.log('AppToken: ' + SymAppAuthToken)
-      SymBotAuth.appAuthToken = SymAppAuthToken.token
-      defer.resolve(SymAppAuthToken.token)
-    })
-    res.on('error', function (err) {
-      console.log('[ERROR]', 'SymBotAuth/applicationAuthenticate/err', err)
-    })
+  return request(options, 'SymBotAuth/applicationAuthenticate', body).then(({ token }) => {
+    SymBotAuth.appAuthToken = token
+    return token
   })
-
-  if (symConfig.authType === 'rsa') {
-    req.write(JSON.stringify(jwtToken))
-  }
-
-  req.end()
-
-  return defer.promise
 }
 
 // User Authenticate by UserId required for enabling OBO https://rest-api.symphony.com/reference#obo-user-authenticate
 SymBotAuth.oboAuthenticateByUserId = (userId) => {
-  var defer = Q.defer()
-
-  var options = {}
-  var jwtToken
+  var options
+  var body
 
   if (SymBotAuth.symConfig.authType === 'rsa') {
-    jwtToken = { 'token': SymBotAuth.getJwtToken(SymBotAuth.symConfig) }
+    body = { 'token': SymBotAuth.getJwtToken(SymBotAuth.symConfig) }
 
     options = {
       'hostname': SymBotAuth.symConfig.podHost,
@@ -218,43 +148,19 @@ SymBotAuth.oboAuthenticateByUserId = (userId) => {
     }
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'SymBotAuth/userIdAuthenticate/str', str)
-      }
-      var SymAppAuthToken = JSON.parse(str)
-      console.log('AppToken: ' + SymAppAuthToken)
-      SymBotAuth.appAuthToken = SymAppAuthToken.token
-      defer.resolve(SymAppAuthToken.token)
-    })
-    res.on('error', function (err) {
-      console.log('[ERROR]', 'SymBotAuth/userIdAuthenticate/err', err)
-    })
+  return request(options, 'SymBotAuth/userIdAuthenticate', body).then(({ token }) => {
+    SymBotAuth.appAuthToken = token
+    return token
   })
-
-  if (SymBotAuth.symConfig.authType === 'rsa') {
-    req.write(JSON.stringify(jwtToken))
-  }
-
-  req.end()
-
-  return defer.promise
 }
 
 // User Authenticate by Username required for enabling OBO https://rest-api.symphony.com/reference#obo-user-authenticate
 SymBotAuth.oboAuthenticateByUsername = (symConfig, username) => {
-  var defer = Q.defer()
-
-  var options = {}
-  var jwtToken
+  var options
+  var body
 
   if (symConfig.authType === 'rsa') {
-    jwtToken = { 'token': SymBotAuth.getJwtToken(symConfig) }
+    body = { 'token': SymBotAuth.getJwtToken(symConfig) }
 
     options = {
       'hostname': symConfig.podHost,
@@ -279,37 +185,13 @@ SymBotAuth.oboAuthenticateByUsername = (symConfig, username) => {
     }
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'SymBotAuth/usernameAuthenticate/str', str)
-      }
-      var SymAppAuthToken = JSON.parse(str)
-      console.log('AppToken: ' + SymAppAuthToken)
-      SymBotAuth.appAuthToken = SymAppAuthToken.token
-      defer.resolve(SymAppAuthToken.token)
-    })
-    res.on('error', function (err) {
-      console.log('[ERROR]', 'SymBotAuth/usernameAuthenticate/err', err)
-    })
+  return request(options, 'SymBotAuth/usernameAuthenticate', body).then(({ token }) => {
+    SymBotAuth.appAuthToken = token
+    return token
   })
-
-  if (symConfig.authType === 'rsa') {
-    req.write(JSON.stringify(jwtToken))
-  }
-
-  req.end()
-
-  return defer.promise
 }
 
 SymBotAuth.initBotUser = (symConfig) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': symConfig.podHost,
     'port': symConfig.podPort,
@@ -321,50 +203,30 @@ SymBotAuth.initBotUser = (symConfig) => {
     'agent': symConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'SymBotAuth/initBotUser/str', str)
-      }
-      var results = JSON.parse(str)
-      if (results.users.length > 0) {
-        SymBotAuth.botUser = results.users[0]
-        console.log('--- Symphony Client initialization ---')
-        console.log('The BOT ' + SymBotAuth.botUser.displayName + ' is ready to serve :-)')
-        defer.resolve(results.users[0])
-      } else {
-        defer.resolve({})
-      }
-    })
+  return request(options, 'SymBotAuth/initBotUser').then(({ users }) => {
+    if (users.length > 0) {
+      SymBotAuth.botUser = users[0]
+      console.log('--- Symphony Client initialization ---')
+      console.log('The BOT ' + SymBotAuth.botUser.displayName + ' is ready to serve :-)')
+      return users[0]
+    }
+
+    return {}
   })
-
-  req.end()
-
-  return defer.promise
 }
 
 SymBotAuth.authenticate = (symConfig) => {
-  var defer = Q.defer()
-
   SymBotAuth.symConfig = symConfig
 
-  SymBotAuth.sessionAuthenticate(symConfig)
-    .then((SymSessionToken) => {
-      SymBotAuth.kmAuthenticate(symConfig)
-        .then((SymKmToken) => {
-          SymBotAuth.initBotUser(symConfig)
-          defer.resolve({ 'sessionAuthToken': SymSessionToken, 'kmAuthToken': SymKmToken })
-        })
-        .fail((err) => {
-          console.log('err authenticate', err)
-        })
+  return SymBotAuth.sessionAuthenticate(symConfig).then((SymSessionToken) =>
+    SymBotAuth.kmAuthenticate(symConfig).then((SymKmToken) =>
+      SymBotAuth.initBotUser(symConfig).then(() => ({
+        'sessionAuthToken': SymSessionToken,
+        'kmAuthToken': SymKmToken
+      }))))
+    .fail((err) => {
+      console.log('err authenticate', err)
     })
-
-  return defer.promise
 }
 
 SymBotAuth.nowEpochSeconds = () => {

--- a/lib/SymBotClient/index.js
+++ b/lib/SymBotClient/index.js
@@ -11,7 +11,6 @@ const SignalsClient = require('../SignalsClient')
 const StreamsClient = require('../StreamsClient')
 const UsersClient = require('../UsersClient')
 const PresenceClient = require('../PresenceClient')
-const Q = require('kew')
 
 var SymBotClient = {}
 
@@ -21,17 +20,11 @@ SymBotClient.MESSAGEML_FORMAT = MessagesClient.MESSAGEML_FORMAT
 SymBotClient.sessionToken = {}
 
 SymBotClient.initBot = (pathToConfigFile) => {
-  var defer = Q.defer()
-
-  SymConfigLoader.loadFromFile(pathToConfigFile).then(SymConfig => {
-    SymBotAuth.authenticate(SymConfig).then((symAuth) => {
-      defer.resolve({ 'config': SymConfig, 'sessionAuthToken': symAuth.sessionAuthToken, 'kmAuthToken': symAuth.kmAuthToken })
+  return SymConfigLoader.loadFromFile(pathToConfigFile).then(SymConfig => {
+    return SymBotAuth.authenticate(SymConfig).then((symAuth) => {
+      return { 'config': SymConfig, 'sessionAuthToken': symAuth.sessionAuthToken, 'kmAuthToken': symAuth.kmAuthToken }
     })
-  }).fail((err) => {
-    defer.reject(err)
   })
-
-  return defer.promise
 }
 
 SymBotClient.getBotUser = () => {
@@ -40,600 +33,96 @@ SymBotClient.getBotUser = () => {
 
 /* AdminClient Services */
 
-SymBotClient.adminListEnterpriseStreamsV2 = (streamTypes, scope, origin, privacy, status, startDate, endDate, skip, limit) => {
-  var defer = Q.defer()
-
-  AdminClient.adminListEnterpriseStreamsV2(streamTypes, scope, origin, privacy, status, startDate, endDate, skip, limit).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.streamMembers = (id, skip, limit) => {
-  var defer = Q.defer()
-
-  AdminClient.streamMembers(id, skip, limit).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.importMessages = (messageList) => {
-  var defer = Q.defer()
-
-  AdminClient.importMessages(messageList).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.suppressMessage = (id) => {
-  var defer = Q.defer()
-
-  AdminClient.suppressMessage(id).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
+SymBotClient.adminListEnterpriseStreamsV2 = AdminClient.adminListEnterpriseStreamsV2
+SymBotClient.streamMembers = AdminClient.streamMembers
+SymBotClient.importMessages = AdminClient.importMessages
+SymBotClient.suppressMessage = AdminClient.suppressMessage
 
 /* AdminUserClient Services */
 
-SymBotClient.getUser = (id) => {
-  var defer = Q.defer()
-
-  AdminUserClient.getUser(id).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.listUsers = (skip, limit) => {
-  var defer = Q.defer()
-
-  AdminUserClient.listUsers(skip, limit).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
+SymBotClient.getUser = AdminUserClient.getUser
+SymBotClient.listUsers = AdminUserClient.listUsers
 
 /* ConnectionsClient Services */
 
-SymBotClient.getPendingConnections = (status) => {
-  var defer = Q.defer()
-
-  ConnectionsClient.getPendingConnections(status).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.getInboundPendingConnections = (status) => {
-  var defer = Q.defer()
-
-  ConnectionsClient.getInboundPendingConnections(status).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.getAllConnections = (status) => {
-  var defer = Q.defer()
-
-  ConnectionsClient.getAllConnections(status).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.getAcceptedConnections = (status) => {
-  var defer = Q.defer()
-
-  ConnectionsClient.getAcceptedConnections(status).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.getRejectedConnections = (status) => {
-  var defer = Q.defer()
-
-  ConnectionsClient.getRejectedConnections(status).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.getConnections = (status, userIds) => {
-  var defer = Q.defer()
-
-  ConnectionsClient.getConnections(status, userIds).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.acceptConnectionRequest = (userId) => {
-  var defer = Q.defer()
-
-  ConnectionsClient.acceptConnectionRequest(userId).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.rejectConnectionRequest = (userId) => {
-  var defer = Q.defer()
-
-  ConnectionsClient.rejectConnectionRequest(userId).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.sendConnectionRequest = (userId) => {
-  var defer = Q.defer()
-
-  ConnectionsClient.sendConnectionRequest(userId).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.removeConnection = (userId) => {
-  var defer = Q.defer()
-
-  ConnectionsClient.removeConnection(userId).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.getConnectionRequestStatus = (userId) => {
-  var defer = Q.defer()
-
-  ConnectionsClient.getConnectionRequestStatus(userId).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
+SymBotClient.getPendingConnections = ConnectionsClient.getPendingConnections
+SymBotClient.getInboundPendingConnections = ConnectionsClient.getInboundPendingConnections
+SymBotClient.getAllConnections = ConnectionsClient.getAllConnections
+SymBotClient.getAcceptedConnections = ConnectionsClient.getAcceptedConnections
+SymBotClient.getRejectedConnections = ConnectionsClient.getRejectedConnections
+SymBotClient.getConnections = ConnectionsClient.getConnections
+SymBotClient.acceptConnectionRequest = ConnectionsClient.acceptConnectionRequest
+SymBotClient.rejectConnectionRequest = ConnectionsClient.rejectConnectionRequest
+SymBotClient.sendConnectionRequest = ConnectionsClient.sendConnectionRequest
+SymBotClient.removeConnection = ConnectionsClient.removeConnection
+SymBotClient.getConnectionRequestStatus = ConnectionsClient.getConnectionRequestStatus
 
 /* DatafeedClient Services */
 
-SymBotClient.getDatafeedEventsService = (subscriberCallback) => {
-  DatafeedEventsService.initService(subscriberCallback)
-}
-
-SymBotClient.stopDatafeedEventsService = () => {
-  DatafeedEventsService.stopService()
-}
+SymBotClient.getDatafeedEventsService = DatafeedEventsService.initService
+SymBotClient.stopDatafeedEventsService = DatafeedEventsService.stopService
 
 /* FirehoseClient Services */
 
-SymBotClient.getFirehoseEventsService = (subscriberCallback) => {
-  FirehoseEventsService.initService(subscriberCallback)
-}
-
-SymBotClient.stopFirehoseEventsService = () => {
-  FirehoseEventsService.stopService()
-}
+SymBotClient.getFirehoseEventsService = FirehoseEventsService.initService
+SymBotClient.stopFirehoseEventsService = FirehoseEventsService.stopService
 
 /* MessagesClient Services */
 
-SymBotClient.sendMessage = (conversationId, message, data, format) => {
-  var defer = Q.defer()
-
-  MessagesClient.sendMessage(conversationId, message, data, format).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.sendMessageWithAttachment = (conversationId, message, data, fileName, fileType, fileContent, format) => {
-  var defer = Q.defer()
-
-  MessagesClient.sendMessageWithAttachment(conversationId, message, data, fileName, fileType, fileContent, format).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.forwardMessage = (conversationId, message, data) => {
-  var defer = Q.defer()
-
-  MessagesClient.forwardMessage(conversationId, message, data).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.getAttachment = (streamId, attachmentId, messageId) => {
-  var defer = Q.defer()
-
-  MessagesClient.getAttachment(streamId, attachmentId, messageId).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.getMessage = (messageId) => {
-  var defer = Q.defer()
-
-  MessagesClient.getMessage(messageId).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
+SymBotClient.sendMessage = MessagesClient.sendMessage
+SymBotClient.sendMessageWithAttachment = MessagesClient.sendMessageWithAttachment
+SymBotClient.forwardMessage = MessagesClient.forwardMessage
+SymBotClient.getAttachment = MessagesClient.getAttachment
+SymBotClient.getMessage = MessagesClient.getMessage
 
 /* On Behalf Of - OBOClient Services */
-SymBotClient.oboAuthenticateByUserId = (userId) => {
-  var defer = Q.defer()
 
-  SymBotAuth.oboAuthenticateByUserId(userId).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.oboGetAllConnections = (status) => {
-  var defer = Q.defer()
-
-  OBOClient.oboGetAllConnections(status).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.oboGetConnection = (userId) => {
-  var defer = Q.defer()
-
-  OBOClient.oboGetConnection(userId).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.oboGetUserIMStreamId = (userIds) => {
-  var defer = Q.defer()
-
-  OBOClient.oboGetUserIMStreamId(userIds).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.oboSendMessage = (conversationId, message, data, format) => {
-  var defer = Q.defer()
-
-  OBOClient.oboSendMessage(conversationId, message, data, format).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
+SymBotClient.oboAuthenticateByUserId = SymBotAuth.oboAuthenticateByUserId
+SymBotClient.oboGetAllConnections = OBOClient.oboGetAllConnections
+SymBotClient.oboGetConnection = OBOClient.oboGetConnection
+SymBotClient.oboGetUserIMStreamId = OBOClient.oboGetUserIMStreamId
+SymBotClient.oboSendMessage = OBOClient.oboSendMessage
 
 /* SignalsClient Services */
 
-SymBotClient.listSignals = (skip, limit) => {
-  var defer = Q.defer()
-
-  SignalsClient.listSignals(skip, limit).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.getSignal = (id) => {
-  var defer = Q.defer()
-
-  SignalsClient.getSignal(id).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.createSignal = (name, query, visibleOnProfile, companyWide) => {
-  var defer = Q.defer()
-
-  SignalsClient.createSignal(name, query, visibleOnProfile, companyWide).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.updateSignal = (id, name, query, visibleOnProfile, companyWide) => {
-  var defer = Q.defer()
-
-  SignalsClient.updateSignal(id, name, query, visibleOnProfile, companyWide).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.deleteSignal = (id) => {
-  var defer = Q.defer()
-
-  SignalsClient.deleteSignal(id).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.subscribeSignal = (id, userIds, userCanUnsubscribe) => {
-  var defer = Q.defer()
-
-  SignalsClient.subscribeSignal(id, userIds, userCanUnsubscribe).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.unsubscribeSignal = (id, userIds) => {
-  var defer = Q.defer()
-
-  SignalsClient.unsubscribeSignal(id, userIds).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.getSignalSubscribers = (id, skip, limit) => {
-  var defer = Q.defer()
-
-  SignalsClient.getSignalSubscribers(id, skip, limit).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
+SymBotClient.listSignals = SignalsClient.listSignals
+SymBotClient.getSignal = SignalsClient.getSignal
+SymBotClient.createSignal = SignalsClient.createSignal
+SymBotClient.updateSignal = SignalsClient.updateSignal
+SymBotClient.deleteSignal = SignalsClient.deleteSignal
+SymBotClient.subscribeSignal = SignalsClient.subscribeSignal
+SymBotClient.unsubscribeSignal = SignalsClient.unsubscribeSignal
+SymBotClient.getSignalSubscribers = SignalsClient.getSignalSubscribers
 
 /* StreamsClient Services */
 
-SymBotClient.getUserIMStreamId = (userId) => {
-  var defer = Q.defer()
-
-  StreamsClient.getUserIMStreamId(userId).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.createRoom = (room, description, keywords, membersCanInvite, discoverable, anyoneCanJoin, readOnly, copyProtected, crossPod, viewHistory) => {
-  var defer = Q.defer()
-
-  StreamsClient.createRoom(room, description, keywords, membersCanInvite, discoverable, anyoneCanJoin, readOnly, copyProtected, crossPod, viewHistory).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.updateRoom = (streamId, room, description, keywords, membersCanInvite, discoverable, anyoneCanJoin, readOnly, copyProtected, crossPod, viewHistory) => {
-  var defer = Q.defer()
-
-  StreamsClient.updateRoom(streamId, room, description, keywords, membersCanInvite, discoverable, anyoneCanJoin, readOnly, copyProtected, crossPod, viewHistory).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.getRoomInfo = (streamId) => {
-  var defer = Q.defer()
-
-  StreamsClient.getRoomInfo(streamId).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.activateRoom = (streamId) => {
-  var defer = Q.defer()
-
-  StreamsClient.activateRoom(streamId).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.deactivateRoom = (streamId) => {
-  var defer = Q.defer()
-
-  StreamsClient.deactivateRoom(streamId).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.getRoomMembers = (streamId) => {
-  var defer = Q.defer()
-
-  StreamsClient.getRoomMembers(streamId).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.addMemberToRoom = (streamId, userId) => {
-  var defer = Q.defer()
-
-  StreamsClient.addMemberToRoom(streamId, userId).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.removeMemberFromRoom = (streamId, userId) => {
-  var defer = Q.defer()
-
-  StreamsClient.removeMemberFromRoom(streamId, userId).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.promoteUserToOwner = (streamId, userId) => {
-  var defer = Q.defer()
-
-  StreamsClient.promoteUserToOwner(streamId, userId).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.demoteUserFromOwner = (streamId, userId) => {
-  var defer = Q.defer()
-
-  StreamsClient.demoteUserFromOwner(streamId, userId).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.searchRooms = (skip, limit, query, labels, active, includePrivateRooms, creator, owner, member, sortOrder) => {
-  var defer = Q.defer()
-
-  StreamsClient.searchRooms(skip, limit, query, labels, active, includePrivateRooms, creator, owner, member, sortOrder).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.getUserStreams = (skip, limit, streamTypes, includeInactiveStreams) => {
-  var defer = Q.defer()
-
-  StreamsClient.getUserStreams(skip, limit, streamTypes, includeInactiveStreams).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
+SymBotClient.getUserIMStreamId = StreamsClient.getUserIMStreamId
+SymBotClient.createRoom = StreamsClient.createRoom
+SymBotClient.updateRoom = StreamsClient.updateRoom
+SymBotClient.getRoomInfo = StreamsClient.getRoomInfo
+SymBotClient.activateRoom = StreamsClient.activateRoom
+SymBotClient.deactivateRoom = StreamsClient.deactivateRoom
+SymBotClient.getRoomMembers = StreamsClient.getRoomMembers
+SymBotClient.addMemberToRoom = StreamsClient.addMemberToRoom
+SymBotClient.removeMemberFromRoom = StreamsClient.removeMemberFromRoom
+SymBotClient.promoteUserToOwner = StreamsClient.promoteUserToOwner
+SymBotClient.demoteUserFromOwner = StreamsClient.demoteUserFromOwner
+SymBotClient.searchRooms = StreamsClient.searchRooms
+SymBotClient.getUserStreams = StreamsClient.getUserStreams
 
 /* UsersClient Services */
 
-SymBotClient.getUserFromUsername = (username) => {
-  var defer = Q.defer()
-
-  UsersClient.getUserFromUsername(username).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.getUserFromEmail = (email, local) => {
-  var defer = Q.defer()
-
-  UsersClient.getUserFromEmail(email, local).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.getUsersFromEmailList = (emailList, local) => {
-  var defer = Q.defer()
-
-  UsersClient.getUsersFromEmailList(emailList, local).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.getUsersFromIdList = (idList, local) => {
-  var defer = Q.defer()
-
-  UsersClient.getUsersFromIdList(idList, local).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.searchUsers = (query, local, skip, limit, filter) => {
-  var defer = Q.defer()
-
-  UsersClient.searchUsers(query, local, skip, limit, filter).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
+SymBotClient.getUserFromUsername = UsersClient.getUserFromUsername
+SymBotClient.getUserFromEmail = UsersClient.getUserFromEmail
+SymBotClient.getUsersFromEmailList = UsersClient.getUsersFromEmailList
+SymBotClient.getUsersFromIdList = UsersClient.getUsersFromIdList
+SymBotClient.searchUsers = UsersClient.searchUsers
 
 /* Presence Services */
 
-SymBotClient.getUserPresence = (userId, local) => {
-  var defer = Q.defer()
-
-  PresenceClient.getUserPresence(userId, local).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.setPresence = (status) => {
-  var defer = Q.defer()
-
-  PresenceClient.setPresence(status).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
-
-SymBotClient.registerInterestExtUser = (idList) => {
-  var defer = Q.defer()
-
-  PresenceClient.registerInterestExtUser(idList).then((res) => {
-    defer.resolve(res)
-  })
-
-  return defer.promise
-}
+SymBotClient.getUserPresence = PresenceClient.getUserPresence
+SymBotClient.setPresence = PresenceClient.setPresence
+SymBotClient.registerInterestExtUser = PresenceClient.registerInterestExtUser
 
 /* Other Services */
 

--- a/lib/UsersClient/index.js
+++ b/lib/UsersClient/index.js
@@ -1,14 +1,11 @@
-const https = require('https')
-const Q = require('kew')
 const SymConfigLoader = require('../SymConfigLoader')
 const SymBotAuth = require('../SymBotAuth')
+const request = require('../Request')
 
 var UsersClient = {}
 
 // Look up user with a username via https://rest-api.symphony.com/reference#user-lookup
 UsersClient.getUserFromUsername = (username) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -20,28 +17,11 @@ UsersClient.getUserFromUsername = (username) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'UsersClient/getUserFromUsername/str', str)
-      }
-      defer.resolve((str === '') ? {} : JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'UsersClient/getUserFromUsername')
 }
 
 // Look up user with an email via https://rest-api.symphony.com/reference#user-lookup
 UsersClient.getUserFromEmail = (email, local) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -53,28 +33,11 @@ UsersClient.getUserFromEmail = (email, local) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'UsersClient/getUserFromEmail/str', str)
-      }
-      defer.resolve((str === '') ? {} : JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'UsersClient/getUserFromEmail')
 }
 
 // Look up user with an email via https://rest-api.symphony.com/reference#users-lookup-v3
 UsersClient.getUserFromEmailV3 = (email, local) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -86,28 +49,11 @@ UsersClient.getUserFromEmailV3 = (email, local) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'UsersClient/getUserFromEmailV3/str', str)
-      }
-      defer.resolve((str === '') ? {} : JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'UsersClient/getUserFromEmailV3')
 }
 
 // Look up user with a userID via https://rest-api.symphony.com/reference#users-lookup-v3
 UsersClient.getUserFromIdV3 = (id, local) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -119,22 +65,7 @@ UsersClient.getUserFromIdV3 = (id, local) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'UsersClient/getUserFromIdV3/str', str)
-      }
-      defer.resolve((str === '') ? {} : JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'UsersClient/getUserFromIdV3')
 }
 
 // Look up multiple users with an email via https://rest-api.symphony.com/reference#users-lookup-v3
@@ -148,7 +79,6 @@ UsersClient.getUsersFromIdList = (idList, local) => {
 }
 
 UsersClient.getUsersV3 = (emailList, idList, local) => {
-  var defer = Q.defer()
   var listPart  = (emailList ? `email=${emailList}` : `uid=${idList}`);
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
@@ -161,28 +91,11 @@ UsersClient.getUsersV3 = (emailList, idList, local) => {
     'agent': SymConfigLoader.SymConfig.podProxy
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'UsersClient/getUsersV3/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
-
-  req.end()
-
-  return defer.promise
+  return request(options, 'UsersClient/getUsersV3')
 }
 
 // Search for users using https://rest-api.symphony.com/reference#search-users
 UsersClient.searchUsers = (query, local, skip, limit, filter) => {
-  var defer = Q.defer()
-
   var options = {
     'hostname': SymConfigLoader.SymConfig.podHost,
     'port': SymConfigLoader.SymConfig.podPort,
@@ -199,23 +112,8 @@ UsersClient.searchUsers = (query, local, skip, limit, filter) => {
     'filter': filter
   }
 
-  var req = https.request(options, function (res) {
-    var str = ''
-    res.on('data', function (chunk) {
-      str += chunk
-    })
-    res.on('end', function () {
-      if (SymBotAuth.debug) {
-        console.log('[DEBUG]', 'UsersClient/searchUsers/str', str)
-      }
-      defer.resolve(JSON.parse(str))
-    })
-  })
+  return request(options, 'UsersClient/searchUsers', body)
 
-  req.write(body)
-  req.end()
-
-  return defer.promise
 }
 
 module.exports = UsersClient


### PR DESCRIPTION
- Always reject the promise if the network request fails (previously only some endpoints did)
- If debugging is turned on, also log an error (previously some always logged, some never logged and some logged only if debugging was on)
- Propagate promise rejections up the chain (previously some rejections were lost due to only resolutions being handled)
- Always parse empty response as `{}` (previously only some endpoints did this; those that didn't would have had an unhandled promise rejection on encountering an empty response)